### PR TITLE
feat: 直接実行時のバージョン情報にブランチ名・コミット日時を追加

### DIFF
--- a/server/settings_service.py
+++ b/server/settings_service.py
@@ -70,6 +70,42 @@ def resolve_git_hash(repo_root: Path) -> str:
     return result.stdout.strip() or "unknown"
 
 
+def resolve_git_branch(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except FileNotFoundError:
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def resolve_git_commit_date(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ci"],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+    except FileNotFoundError:
+        return ""
+    if result.returncode != 0 or not result.stdout.strip():
+        return ""
+    try:
+        dt = datetime.strptime(result.stdout.strip()[:19], "%Y-%m-%d %H:%M:%S")
+        return dt.strftime("%Y.%m.%d %H:%M")
+    except ValueError:
+        return result.stdout.strip()[:16]
+
+
 def resolve_build_time() -> str:
     if not VERSION_PATH.exists():
         return ""
@@ -176,13 +212,13 @@ def get_dynamic_version(repo_root: Path) -> dict:
     
     # Fallback: 上流のバージョンロジック（Python直接起動時）
     try:
-        version_data = load_version_data()
         git_hash = resolve_git_hash(repo_root)
+        git_branch = resolve_git_branch(repo_root)
         import fastapi
         return {
-            "app": f"{version_data.get('version', '0.1.0')}@{git_hash}",
+            "app": f"{git_branch}@{git_hash}",
             "api": f"FastAPI {fastapi.__version__}",
-            "build": resolve_build_time()
+            "build": resolve_git_commit_date(repo_root)
         }
     except Exception:
         # Git情報取得失敗時のフォールバック


### PR DESCRIPTION
## 概要

venvで `server/app.py` を直接実行する環境でのバージョン情報表示を改善します。

## 変更内容

`server/settings_service.py` に2つの関数を追加し、`get_dynamic_version()` のfallbackを更新します。

### 追加した関数
- `resolve_git_branch(repo_root)`: `git rev-parse --abbrev-ref HEAD` でブランチ名を取得
- `resolve_git_commit_date(repo_root)`: `git log -1 --format=%ci` で最終コミット日時を取得

### 変更前後の比較（直接実行時）

| フィールド | 変更前 | 変更後 |
|---|---|---|
| `app` | `0.1.0@abc1234`（バージョン番号） | `main@abc1234`（ブランチ名） |
| `build` | `version.json` のmtime（不正確）| 最終コミット日時 |

### 環境別の動作

| 実行方法 | `app` | `build` |
|---|---|---|
| 環境変数あり（例: Docker）| 変更なし（env vars優先）| 変更なし |
| **venv + 直接実行** | `main@abc1234` ← 改善 | `2026.03.04 14:59` ← 改善 |
| git なし / リポジトリ外 | `unknown@unknown` | 空文字 |

gitが利用できない環境では `unknown` にフォールバックするため、後方互換性があります。