### PR TITLE
fix: メディアカードの長いタイトル・作者名を自動スクロール表示

### DIFF
--- a/server/static/app.js
+++ b/server/static/app.js
@@ -837,9 +837,9 @@ const renderMedia = () => {
     card.innerHTML = `
       ${selectionState.active ? `<input type="checkbox" class="media-list-checkbox" ${selectionState.selectedIds.has(track.id) ? "checked" : ""} style="margin-bottom:6px" />` : ""}
       <img src="${track.cover}" alt="${track.album}" />
-      <h3>${track.title}</h3>
-      <p>${track.artist}</p>
-      <p>${track.album}</p>
+      <h3><span class="scroll-text">${track.title}</span></h3>
+      <p><span class="scroll-text">${track.artist}</span></p>
+      <p><span class="scroll-text">${track.album}</span></p>
       <div class="media-meta">
         <span>${track.genre} ・ ${track.year}</span>
         <span>${track.duration}</span>
@@ -883,9 +883,10 @@ const renderMedia = () => {
 
   // はみ出しているテキストに自動スクロールアニメーションを適用
   requestAnimationFrame(() => {
-    mediaGrid.querySelectorAll(".media-card h3, .media-card p").forEach((el) => {
-      if (el.scrollWidth > el.clientWidth) {
-        el.style.setProperty("--overflow-width", `-${el.scrollWidth - el.clientWidth}px`);
+    mediaGrid.querySelectorAll(".media-card .scroll-text").forEach((el) => {
+      const parent = el.parentElement;
+      if (el.scrollWidth > parent.clientWidth) {
+        el.style.setProperty("--overflow-width", `-${el.scrollWidth - parent.clientWidth}px`);
         el.classList.add("is-overflowing");
       }
     });

--- a/server/static/styles.css
+++ b/server/static/styles.css
@@ -267,13 +267,16 @@ body {
 }
 
 @keyframes media-text-scroll {
-  from { transform: translateX(0); }
-  to   { transform: translateX(var(--overflow-width, 0px)); }
+  0%, 15%  { transform: translateX(0); }
+  85%, 100% { transform: translateX(var(--overflow-width, 0px)); }
 }
 
-.media-card h3.is-overflowing,
-.media-card p.is-overflowing {
-  animation: media-text-scroll 3s 1s ease-in-out infinite alternate;
+.media-card .scroll-text {
+  display: inline-block;
+}
+
+.media-card .scroll-text.is-overflowing {
+  animation: media-text-scroll 4s linear infinite alternate;
 }
 
 .media-meta {


### PR DESCRIPTION
## 変更内容

メディアカード（グリッド表示）でタイトルや作者名が長い場合、文字が見切れたまま高さが変わらず、カードの高さが不揃いになる問題を修正しました。

**変更前：** 長いテキストが折り返して高さがバラバラ → 再生ボタンの位置がカードごとに異なる
**変更後：** テキストを1行に固定し、はみ出している場合のみ左方向へ自動スクロール（停止→移動→停止を繰り返す）

---

## Changes

Fixed an issue in media card (grid view) where long titles or artist names would wrap to multiple lines, causing inconsistent card heights and misaligned play buttons.

**Before:** Long text wraps → cards have different heights → play button positions vary per card
**After:** Text is clamped to a single line; if it overflows, it auto-scrolls left in a loop (pause → scroll → pause)

---

## Modified files

- `server/static/styles.css`: `white-space: nowrap` + `overflow: hidden` + `@keyframes media-text-scroll` (linear, alternate)
- `server/static/app.js`: Wrap text nodes in `<span class="scroll-text">`, detect overflow with `scrollWidth > clientWidth`, apply `is-overflowing` class + CSS variable `--overflow-width`