### PR TITLE
fix: ダウンロード完了ログが「0件成功0件失敗」になるバグを修正

### DIFF
--- a/server/ytdlp_service.py
+++ b/server/ytdlp_service.py
@@ -145,9 +145,13 @@ def iter_ytdlp_events(url: str, playlist_id: str | None = None, no_playlist: boo
         yield {"type": "error", "message": "yt-dlp did not return metadata"}
         return
     tracks = store_downloaded_tracks(infos, url, playlist_id)
+    failed_count = len(infos) - len(tracks)
     yield {
         "type": "complete",
         "tracks": [asdict(track) for track in tracks],
+        "completed": len(tracks),
+        "failed": failed_count,
+        "total": len(infos),
     }
 
 


### PR DESCRIPTION
## 変更内容

ダウンロード完了後のログに「0件成功, 0件失敗」と表示される問題を修正しました。

**原因：** `iter_ytdlp_events()` が送る `complete` イベントに `tracks` 配列しか含まれておらず、フロントエンドが参照する `completed` / `failed` フィールドが存在しなかった。

**修正：** `store_downloaded_tracks` の結果と `infos`（yt-dlp取得メタデータ）の差分から件数を算出して送信。

---

## Changes

Fixed a bug where the download completion log always showed "0 succeeded, 0 failed".

**Cause:** The `complete` event from `iter_ytdlp_events()` only contained the `tracks` array; the `completed` / `failed` fields read by the frontend were missing (evaluated as `0`).

**Fix:** Calculate counts from `store_downloaded_tracks` result vs `infos` length and include them in the event.

## Modified file

`server/ytdlp_service.py` — `iter_ytdlp_events()` complete event